### PR TITLE
azure stats reimplementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -166,3 +166,4 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+**/.DS_Store

--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -5,8 +5,26 @@ defaults:
 
 report:
 pipeline:
+- list_blob_contents
   # - export_blob_metrics
-  - list_blob_contents
   # - local_batch_table_generator
+
 #folders and their corresponding ile types that will be matched in the data directory
 matching_folders: {'images':'jpg','instance_masks':'png','semantic_masks':'png','metadata':'json'}
+
+list_blob_contents:
+  unprocessed_folders: 
+    - images
+    - autosfm
+    - metadata
+    - meta_masks
+  processed_folders: 
+    - autosfm
+    - metadata
+    - meta_masks
+  file_extensions:
+    images: ['.jpg']
+  batch_prefixes:
+    - MD
+    - TX
+    - NC

--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -24,6 +24,10 @@ list_blob_contents:
     - meta_masks
   file_extensions:
     images: ['.jpg']
+    raw_images: ['.arw', '.raw']
+    metadata: ['.json']
+    meta_masks/semantic_masks: ['.png']
+    
   batch_prefixes:
     - MD
     - TX

--- a/conf/paths/default.yaml
+++ b/conf/paths/default.yaml
@@ -15,5 +15,7 @@ report: ${paths.root_dir}/reports/
 pipeline_keys: ${paths.root_dir}/keys/authorized_keys.yaml
 
 # NCSU Storage lockers
-longterm_images: /mnt/research-projects/s/screberg/longterm_images
-GROW_DATA: /mnt/research-projects/s/screberg/GROW_DATA
+# longterm_images: /mnt/research-projects/s/screberg/longterm_images
+# GROW_DATA: /mnt/research-projects/s/screberg/GROW_DATA
+longterm_images: /Volumes/screberg/longterm_images
+GROW_DATA: /Volumes/screberg/GROW_DATA

--- a/src/list_blob_contents.py
+++ b/src/list_blob_contents.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from omegaconf import DictConfig
 from tqdm import tqdm
 import os
-from utils.utils import read_yaml
+from utils.utils import read_yaml, format_az_file_list
 from concurrent.futures import ProcessPoolExecutor
 import subprocess
 
@@ -63,9 +63,17 @@ class ExporterBlobMetrics:
             outputtxt = Path(self.output_dir, k + ".txt")
             with open(outputtxt, "w") as f:
                 f.write(output)
+                
+    def get_data_splits(self):
+        """Retrieve and return lists of cutout and developed images."""
+        cutouts_blob_data = format_az_file_list(os.path.join(self.output_dir, 'semifield-cutouts.txt'))
+        developed_blob_data = format_az_file_list(os.path.join(self.output_dir, 'semifield-developed-images.txt'))
+        log.info(cutouts_blob_data.keys())
+        log.info(developed_blob_data.keys())
 
 def main(cfg: DictConfig) -> None:
     """Main function to execute the BlobMetricExporter."""
     exporter = ExporterBlobMetrics(cfg)
-    exporter.run_azcopy_ls()
+    # exporter.run_azcopy_ls()
     log.info("Extracting data completed.")
+    exporter.get_data_splits()

--- a/src/utils/utils.py
+++ b/src/utils/utils.py
@@ -43,6 +43,13 @@ def format_az_file_list(main_file, unprocessed_folder_list=None, processed_folde
 
     filelines =  open(main_file, 'r').readlines()
     for line in filelines:
+        if not line.strip():
+            continue
+        
+        # ignores 'INFO: ' and 'azcopy' from other azcopy versions
+        line = line.replace("INFO: ", "")
+        if "azcopy" in line:
+            continue
         filename, size_string = line.replace('\n','').split(';')
         size_regex = r'Content Length: ([\d.]+) (\w+)'
         match = re.search(size_regex, size_string)

--- a/src/utils/utils.py
+++ b/src/utils/utils.py
@@ -1,6 +1,9 @@
+import re
 import yaml
 import logging
 from tqdm import tqdm
+
+log = logging.getLogger(__name__)
 
 def read_yaml(path: str) -> dict:
     """Reads a YAML file and returns its content as a dictionary."""
@@ -19,3 +22,69 @@ class TqdmLoggingHandler(logging.StreamHandler):
             self.flush()
         except Exception:
             self.handleError(record)
+
+def format_az_file_list(main_file):
+    """
+    args: 
+    filename: text file created by ExportBlobMetrics.run_azcopy_ls
+    returns:
+    data in the following format
+    {
+        '<batch_prefix>': {
+            '<batch_name>': {
+                'files': [(<filename>,<filesize>), (<filename>,<filesize>)],
+                'processed': <True/False>,
+                'total_size': <size in MiB>
+            }
+        }
+    }
+    """
+    # TODO: should the size be in GB/MB?
+    # TODO: processed_data_folders needs to be verified
+    processed_data_folders = {'autosfm', 'metadata', 'masks'}
+    output = {}
+    size_conversion = {"B": 1/1024/2024, "KiB": 1/1024, "MiB": 1, "GiB": 1024}
+
+    filelines =  open(main_file, 'r').readlines()
+    for line in filelines:
+        filename, size_string = line.replace('\n','').split(';')
+        size_regex = r'Content Length: ([\d.]+) (\w+)'
+        match = re.search(size_regex, size_string)
+        if not match:
+            log.warn(f'No size info found: {filename}')
+        num,unit = match.groups()
+        filesize = float(num) * size_conversion[unit]
+        # print(filename, filesize)
+        path_splits = filename.split('/')
+        # try catch block to handle and ignore cases like: MD-2024-04-11
+        try:
+            batch_loc, batch_date = path_splits[0].split('_')[:2] # [:2] added to handle cases like TX_2023-09-11_2
+            if not batch_loc in output:
+                output[batch_loc] = {
+                    batch_date: {
+                        'files': [(filename, filesize)],
+                        'processed': True if any(part in processed_data_folders for part in filename.split('/')) else False
+                    }
+                }
+            elif batch_date in output[batch_loc]:
+                output[batch_loc][batch_date]['files'].append((filename,filesize))
+                if not output[batch_loc][batch_date]['processed'] and any(part in processed_data_folders for part in filename.split('/')):
+                    output[batch_loc][batch_date]['processed'] = True
+            else:
+                # batch_loc is present but batch_date is not
+                output[batch_loc][batch_date] = {
+                    'files':[(filename,filesize)],
+                    'processed': True if any(part in processed_data_folders for part in filename.split('/')) else False
+                }
+        except Exception as e:
+            log.warn(f"Couldn't process file: {filename}")
+        finally:
+            continue
+    
+    # add total size per batch to the output
+    for _, batches in output.items():
+        for _, batch_info in batches.items():
+            total_size = sum(size for _, size in batch_info['files'])
+            batch_info['total_size'] = total_size
+    return output
+

--- a/src/utils/utils.py
+++ b/src/utils/utils.py
@@ -61,21 +61,21 @@ def format_az_file_list(main_file, unprocessed_folder_list=None, processed_folde
                 batch_loc, batch_date = path_splits[0].split('_')[:2] # [:2] added to handle cases like TX_2023-09-11_2
                 if not batch_loc in output:
                     output[batch_loc] = {
-                        batch_date: {
+                        f"{batch_loc}_{batch_date}": {
                             'files': [(filename, filesize)],
-                            'processed': False if not unprocessed_folder_list else True
+                            'has_processed_folders': False if not unprocessed_folder_list else True
                         }
                     }
-                elif batch_date in output[batch_loc]:
-                    output[batch_loc][batch_date]['files'].append((filename,filesize))
+                elif f"{batch_loc}_{batch_date}" in output[batch_loc]:
+                    output[batch_loc][f"{batch_loc}_{batch_date}"]['files'].append((filename,filesize))
                     # if not output[batch_loc][batch_date]['processed'] and any(part in processed_data_folders for part in filename.split('/')):
-                    if not output[batch_loc][batch_date]['processed'] and unprocessed_folder_list:
-                        output[batch_loc][batch_date]['processed'] = True
+                    if not output[batch_loc][f"{batch_loc}_{batch_date}"]['has_processed_folders'] and unprocessed_folder_list:
+                        output[batch_loc][f"{batch_loc}_{batch_date}"]['has_processed_folders'] = True
                 else:
                     # batch_loc is present but batch_date is not
-                    output[batch_loc][batch_date] = {
+                    output[batch_loc][f"{batch_loc}_{batch_date}"] = {
                         'files':[(filename,filesize)],
-                        'processed': False if not unprocessed_folder_list else True
+                        'has_processed_folders': False if not unprocessed_folder_list else True
                     }
             # except Exception as e:
             #     log.warn(f"Couldn't process file: {filename}")
@@ -87,20 +87,20 @@ def format_az_file_list(main_file, unprocessed_folder_list=None, processed_folde
                 batch_loc, batch_date = path_splits[0].split('_')[:2] # [:2] added to handle cases like TX_2023-09-11_2
                 if not batch_loc in output:
                     output[batch_loc] = {
-                        batch_date: {
+                        f"{batch_loc}_{batch_date}": {
                             'files': [(filename, filesize)],
-                            'processed': True if any(part in processed_folder_list for part in path_splits) else False
+                            'has_processed_folders': True if any(part in processed_folder_list for part in path_splits) else False
                         }
                     }
-                elif batch_date in output[batch_loc]:
-                    output[batch_loc][batch_date]['files'].append((filename,filesize))
-                    if not output[batch_loc][batch_date]['processed'] and any(part in processed_folder_list for part in path_splits):
-                        output[batch_loc][batch_date]['processed'] = True
+                elif f"{batch_loc}_{batch_date}" in output[batch_loc]:
+                    output[batch_loc][f"{batch_loc}_{batch_date}"]['files'].append((filename,filesize))
+                    if not output[batch_loc][f"{batch_loc}_{batch_date}"]['has_processed_folders'] and any(part in processed_folder_list for part in path_splits):
+                        output[batch_loc][f"{batch_loc}_{batch_date}"]['has_processed_folders'] = True
                 else:
                     # batch_loc is present but batch_date is not
-                    output[batch_loc][batch_date] = {
+                    output[batch_loc][f"{batch_loc}_{batch_date}"] = {
                         'files':[(filename,filesize)],
-                        'processed': True if any(part in processed_folder_list for part in path_splits) else False
+                        'has_processed_folders': True if any(part in processed_folder_list for part in path_splits) else False
                     }
             # except Exception as e:
             #     log.warn(f"Couldn't process file: {filename}")
@@ -113,9 +113,8 @@ def format_az_file_list(main_file, unprocessed_folder_list=None, processed_folde
 def az_get_batches_size(data, batch_names):
     total_size = 0
     batch_details = [set(batch_name.split('_')) for batch_name in batch_names]
-    # print(batch_details)
     for batch_prefix in data:
         for batch_name, batch_info in data[batch_prefix].items():
-            if batch_name in [x.replace(f"{batch_prefix}_", '') for x in batch_names]:
+            if batch_name in batch_names:
                     total_size += batch_info['total_size']
     return total_size


### PR DESCRIPTION
stats generated:
unpreprocessed vs preprocessed
processed vs unprocessed 

jsonlines output (for each batch):
files
has_processed_folder
total_size (in MiB)
file count

log output eg:
```
[2024-12-02 17:19:19,305][list_blob_contents][INFO] - Found 45 un-preprocessed batches with total size of 1836.4720020369955 GiB
[2024-12-02 17:19:19,325][list_blob_contents][INFO] - Found 472 preprocessed batches with total size of 31833.907442293133 GiB
[2024-12-02 17:19:19,566][list_blob_contents][INFO] - Found 248 unprocessed batches with total size of 17246.226894092517 GiB
[2024-12-02 17:19:19,702][list_blob_contents][INFO] - Found 224 processed batches with total size of 14587.680548200622 GiB
```

**CSV output examples:**
Developed images details:

	path	batch	images	metadata	meta_masks	ImagesFolderSizeGiB	MetadataFolderSizeGiB	MetaMasksFolderSizeGiB	UnProcessed
	azure	NC_2022-09-08	410	463	463	32.817930	0.015703	0.096594	False

Cutout details:

	path	batch	jpg_count	png_count	json_count	mask_count	jpg_size_gib	png_size_gib	json_size_gib	mask_size_gib
	azure	MD_2023-05-13	5597	5605	5601	5607	0.145778	0.153661	0.041881	0.003200
